### PR TITLE
Lower audio quality to pass the 25 MB file limit of the transcription API

### DIFF
--- a/main.py
+++ b/main.py
@@ -11,8 +11,12 @@ def download_audio(youtube_link, file_path):
         "format": "bestaudio/best",
         "outtmpl": f"{file_path}.%(ext)s",
         "postprocessors": [
-            {"key": "FFmpegExtractAudio", "preferredcodec": "mp3", "preferredquality": "192"},
+            {"key": "FFmpegExtractAudio", "preferredcodec": "mp3", "preferredquality": "worse"},
             {"key": "FFmpegMetadata"},
+        ],
+        'postprocessor_args': [
+            '-ar', '16000',  # sample rate
+            '-ac', '1'  # mono
         ],
     }
 


### PR DESCRIPTION
The audio quality is pretty high for an audio transcription, which can still work perfectly with worse audio quality settings. The OpenAI transcription API doesn't accept audio files bigger than 25MB. That's easily hit with videos longer than 30 minutes.

Currently we have 192kps stereo mp3. This PR proposes to use the "worse" bitrate available to ffmpeg (depends on user's instalation of ffmpeg), a sample rate of 16000Hz which cuts off frequencies above 8000Hz (high frequency are not that necessary), and a single audio channel instead of two.

In some rare cases, going from stereo to mono can result in very bad audio quality because of the phase correlation between the two tracks. If that happens, one can remove `'-ac', '1'` from `postprocessor_args`.

For a video of 40 minutes, we went from a tmp_audio.mp3 file of 57 MB (which fails the GPT transcription step) to 7.1 MB. That gives a maximum video duration of ~2h20 that can be summarized.